### PR TITLE
Account UI Improvements

### DIFF
--- a/src/main/java/com/github/mrebhan/ingameaccountswitcher/tools/alt/AltManager.java
+++ b/src/main/java/com/github/mrebhan/ingameaccountswitcher/tools/alt/AltManager.java
@@ -39,10 +39,15 @@ public class AltManager {
 	public Throwable setUser(String username, String password) {
 		Throwable throwable = null;
 		if(!Minecraft.getMinecraft().getSession().getUsername().equals(EncryptionTools.decode(username)) || Minecraft.getMinecraft().getSession().getToken().equals("0")){
-			for (AccountData data : AltDatabase.getInstance().getAlts()) {
-				if (data.alias.equals(Minecraft.getMinecraft().getSession().getUsername()) && data.user.equals(username)) {
-					throwable = new AlreadyLoggedInException();
-					return throwable;
+			if (!Minecraft.getMinecraft().getSession().getToken().equals("0"))
+			{
+				for (AccountData data : AltDatabase.getInstance().getAlts())
+				{
+					if (data.alias.equals(Minecraft.getMinecraft().getSession().getUsername()) && data.user.equals(username))
+					{
+						throwable = new AlreadyLoggedInException();
+						return throwable;
+					}
 				}
 			}
 			this.auth.logOut();

--- a/src/main/java/the_fireplace/ias/gui/AbstractAccountGui.java
+++ b/src/main/java/the_fireplace/ias/gui/AbstractAccountGui.java
@@ -1,0 +1,149 @@
+package the_fireplace.ias.gui;
+
+import com.github.mrebhan.ingameaccountswitcher.tools.alt.AccountData;
+import com.github.mrebhan.ingameaccountswitcher.tools.alt.AltDatabase;
+import net.minecraft.client.gui.GuiButton;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.gui.GuiTextField;
+import net.minecraft.client.resources.I18n;
+import org.lwjgl.input.Keyboard;
+import the_fireplace.iasencrypt.EncryptionTools;
+
+import java.io.IOException;
+
+public abstract class AbstractAccountGui extends GuiScreen
+{
+	private final String actionString;
+	private GuiTextField username;
+	private GuiTextField password;
+	private GuiButton complete;
+
+	public AbstractAccountGui(String actionString)
+	{
+		this.actionString = actionString;
+	}
+
+	@Override
+	public void initGui() {
+		Keyboard.enableRepeatEvents(true);
+		this.buttonList.clear();
+		this.buttonList.add(complete = new GuiButton(2, this.width / 2 - 152, this.height - 28, 150, 20, I18n.format(this.actionString)));
+		this.buttonList.add(new GuiButton(3, this.width / 2 + 2, this.height - 28, 150, 20, I18n.format("gui.cancel")));
+		username = new GuiTextField(0, this.fontRendererObj, this.width / 2 - 100, 60, 200, 20);
+		username.setFocused(true);
+		username.setMaxStringLength(64);
+		password = new GuiPasswordField(1, this.fontRendererObj, this.width / 2 - 100, 90, 200, 20);
+		password.setMaxStringLength(64);
+		complete.enabled = false;
+	}
+
+	@Override
+	public void drawScreen(int par1, int par2, float par3) {
+		this.drawDefaultBackground();
+		this.drawCenteredString(fontRendererObj, I18n.format(this.actionString), this.width / 2, 7, -1);
+		this.drawCenteredString(fontRendererObj, I18n.format("ias.username"), this.width / 2 - 130, 66, -1);
+		this.drawCenteredString(fontRendererObj, I18n.format("ias.password"), this.width / 2 - 130, 96, -1);
+		username.drawTextBox();
+		password.drawTextBox();
+		super.drawScreen(par1, par2, par3);
+	}
+
+	@Override
+	protected void keyTyped(char character, int keyIndex) {
+		if (keyIndex == Keyboard.KEY_ESCAPE) {
+			escape();
+		} else if (keyIndex == Keyboard.KEY_RETURN) {
+			if(username.isFocused()){
+				username.setFocused(false);
+				password.setFocused(true);
+			}else if(password.isFocused() && complete.enabled){
+				complete();
+				escape();
+			}
+		} else if(keyIndex == Keyboard.KEY_TAB){
+			username.setFocused(!username.isFocused());
+			password.setFocused(!password.isFocused());
+		} else {
+			// GuiTextField checks if it's focused before doing anything
+			username.textboxKeyTyped(character, keyIndex);
+			password.textboxKeyTyped(character, keyIndex);
+		}
+	}
+
+	@Override
+	public void updateScreen()
+	{
+		username.updateCursorCounter();
+		password.updateCursorCounter();
+		complete.enabled = canComplete();
+	}
+
+	@Override
+	protected void actionPerformed(GuiButton button){
+		if (button.enabled)
+		{
+			if(button.id == 2){
+				complete();
+				escape();
+			}else if(button.id == 3){
+				escape();
+			}
+		}
+	}
+
+	@Override
+	protected void mouseClicked(int mouseX, int mouseY, int mouseButton) throws IOException {
+		super.mouseClicked(mouseX, mouseY, mouseButton);
+		username.mouseClicked(mouseX, mouseY, mouseButton);
+		password.mouseClicked(mouseX, mouseY, mouseButton);
+	}
+
+	@Override
+	public void onGuiClosed()
+	{
+		Keyboard.enableRepeatEvents(false);
+	}
+
+	/**
+	 * Return to the Account Selector
+	 */
+	private void escape(){
+		mc.displayGuiScreen(new GuiAccountSelector());
+	}
+
+	public String getUsername()
+	{
+		return username.getText();
+	}
+
+	public String getPassword()
+	{
+		return password.getText();
+	}
+
+	public void setUsername(String username)
+	{
+		this.username.setText(username);
+	}
+
+	public void setPassword(String password)
+	{
+		this.password.setText(password);
+	}
+
+	protected boolean accountNotInList(){
+		for(AccountData data : AltDatabase.getInstance().getAlts()){
+			if(EncryptionTools.decode(data.user).equals(getUsername()) && EncryptionTools.decode(data.pass).equals(getPassword())){
+				return false;
+			}
+		}
+		return true;
+	}
+
+	public boolean canComplete()
+	{
+		return getUsername().length() > 0 && getPassword().length() > 0 && accountNotInList();
+	}
+
+	public abstract void complete();
+}

--- a/src/main/java/the_fireplace/ias/gui/GuiAccountSelector.java
+++ b/src/main/java/the_fireplace/ias/gui/GuiAccountSelector.java
@@ -13,6 +13,7 @@ import net.minecraft.client.gui.GuiTextField;
 import net.minecraft.client.resources.I18n;
 import org.apache.commons.lang3.StringUtils;
 import org.lwjgl.input.Keyboard;
+import org.lwjgl.util.Color;
 import the_fireplace.ias.account.AlreadyLoggedInException;
 import the_fireplace.ias.account.ExtendedAccountData;
 import the_fireplace.ias.config.ConfigValues;
@@ -378,13 +379,18 @@ public class GuiAccountSelector extends GuiScreen {
 		@Override
 		protected void drawSlot(int entryID, int p_180791_2_, int p_180791_3_, int p_180791_4_, int p_180791_5_, int p_180791_6_)
 		{
-			String s = GuiAccountSelector.this.queriedaccounts.get(entryID).alias;
+			ExtendedAccountData data = queriedaccounts.get(entryID);
+			String s = data.alias;
 			if (StringUtils.isEmpty(s))
 			{
 				s = I18n.format("ias.alt") + " " + (entryID + 1);
 			}
-
-			GuiAccountSelector.this.drawString(GuiAccountSelector.this.fontRendererObj, s, p_180791_2_ + 2, p_180791_3_ + 1, 16777215);
+			int color = 16777215;
+			if (Minecraft.getMinecraft().getSession().getUsername().equals(data.alias))
+			{
+				color = 0x00FF00;
+			}
+			GuiAccountSelector.this.drawString(GuiAccountSelector.this.fontRendererObj, s, p_180791_2_ + 2, p_180791_3_ + 1, color);
 		}
 	}
 }

--- a/src/main/java/the_fireplace/ias/gui/GuiAddAccount.java
+++ b/src/main/java/the_fireplace/ias/gui/GuiAddAccount.java
@@ -1,182 +1,22 @@
 package the_fireplace.ias.gui;
 
-import com.github.mrebhan.ingameaccountswitcher.tools.alt.AccountData;
 import com.github.mrebhan.ingameaccountswitcher.tools.alt.AltDatabase;
-import net.minecraft.client.gui.GuiButton;
-import net.minecraft.client.gui.GuiScreen;
-import net.minecraft.client.gui.GuiTextField;
-import net.minecraft.client.resources.I18n;
-import org.lwjgl.input.Keyboard;
 import the_fireplace.ias.account.ExtendedAccountData;
-import the_fireplace.iasencrypt.EncryptionTools;
 
-import java.awt.*;
-import java.awt.datatransfer.DataFlavor;
-import java.awt.datatransfer.UnsupportedFlavorException;
-import java.io.IOException;
 /**
  * The GUI where the alt is added
  * @author The_Fireplace
  */
-public class GuiAddAccount extends GuiScreen {
+public class GuiAddAccount extends AbstractAccountGui {
 
-	private String user = "", pass = "", cover = "";
-	private GuiTextField username;
-	private GuiTextField password;
-	private GuiButton addaccount;
-
-	@Override
-	public void initGui() {
-		Keyboard.enableRepeatEvents(true);
-		this.buttonList.clear();
-		this.buttonList.add(addaccount = new GuiButton(2, this.width / 2 - 152, this.height - 28, 150, 20, I18n.format("ias.addaccount")));
-		this.buttonList.add(new GuiButton(3, this.width / 2 + 2, this.height - 28, 150, 20, I18n.format("gui.cancel")));
-		username = new GuiTextField(0, this.fontRendererObj, this.width / 2 - 100, 60, 200, 20);
-		username.setFocused(true);
-		username.setText(user);
-		password = new GuiTextField(1, this.fontRendererObj, this.width / 2 - 100, 90, 200, 20);
-		password.setText(cover);
-		addaccount.enabled = username.getText().length() > 0;
-	}
-
-	@Override
-	public void drawScreen(int par1, int par2, float par3) {
-		this.drawDefaultBackground();
-		this.drawCenteredString(fontRendererObj, I18n.format("ias.addaccount"), this.width / 2, 7, -1);
-		this.drawCenteredString(fontRendererObj, I18n.format("ias.username"), this.width / 2 - 130, 66, -1);
-		this.drawCenteredString(fontRendererObj, I18n.format("ias.password"), this.width / 2 - 130, 96, -1);
-		username.drawTextBox();
-		password.drawTextBox();
-		super.drawScreen(par1, par2, par3);
-	}
-
-	@Override
-	protected void keyTyped(char character, int keyIndex) {
-		if (keyIndex == Keyboard.KEY_ESCAPE) {
-			escape();
-		} else if (keyIndex == Keyboard.KEY_RETURN) {
-			if(username.isFocused()){
-				username.setFocused(false);
-				password.setFocused(true);
-			}else if(password.isFocused() && addaccount.enabled){
-				addAccount();
-			}
-		} else if (keyIndex == Keyboard.KEY_BACK) {
-			if (username.isFocused() && user.length() > 0) {
-				user = user.substring(0, user.length() - 1);
-			} else if (password.isFocused() && pass.length() > 0) {
-				pass = pass.substring(0, pass.length() - 1);
-				cover = cover.substring(0, cover.length() - 1);
-			}
-			updateText();
-		} else if(keyIndex == Keyboard.KEY_TAB){
-			if(username.isFocused()){
-				username.setFocused(false);
-				password.setFocused(true);
-			}else if(password.isFocused()){
-				username.setFocused(true);
-				password.setFocused(false);
-			}
-		} else if (keyIndex == Keyboard.KEY_V && (Keyboard.isKeyDown(Keyboard.KEY_LCONTROL) || Keyboard.isKeyDown(Keyboard.KEY_RCONTROL))){
-			if(username.isFocused()){
-				try {
-					user += (String)Toolkit.getDefaultToolkit().getSystemClipboard().getData(DataFlavor.stringFlavor);
-				} catch (HeadlessException e) {
-					e.printStackTrace();
-				} catch (UnsupportedFlavorException e) {
-					e.printStackTrace();
-				} catch (IOException e) {
-					e.printStackTrace();
-				}
-			}else if(password.isFocused()){
-				try {
-					pass += (String)Toolkit.getDefaultToolkit().getSystemClipboard().getData(DataFlavor.stringFlavor);
-					for(int i=0;i<((String)Toolkit.getDefaultToolkit().getSystemClipboard().getData(DataFlavor.stringFlavor)).length();i++){
-						cover += '*';
-					}
-				} catch (HeadlessException e) {
-					e.printStackTrace();
-				} catch (UnsupportedFlavorException e) {
-					e.printStackTrace();
-				} catch (IOException e) {
-					e.printStackTrace();
-				}
-			}
-		} else if (character != 0) {
-			if (username.isFocused()) {
-				user += character;
-			} else if (password.isFocused()) {
-				pass += character;
-				cover += '*';
-			}
-			updateText();
-		}
-	}
-
-	@Override
-	public void updateScreen()
+	public GuiAddAccount()
 	{
-		this.username.updateCursorCounter();
-		this.password.updateCursorCounter();
-		addaccount.enabled = username.getText().length() > 0 && accountNotInList();
-		updateText();
+		super("ias.addaccount");
 	}
 
 	@Override
-	protected void actionPerformed(GuiButton button){
-		if (button.enabled)
-		{
-			if(button.id == 2){
-				addAccount();
-			}else if(button.id == 3){
-				escape();
-			}
-		}
-	}
-
-	@Override
-	protected void mouseClicked(int mouseX, int mouseY, int mouseButton) throws IOException
+	public void complete()
 	{
-		super.mouseClicked(mouseX, mouseY, mouseButton);
-		username.mouseClicked(mouseX, mouseY, mouseButton);
-		password.mouseClicked(mouseX, mouseY, mouseButton);
-	}
-
-	@Override
-	public void onGuiClosed()
-	{
-		Keyboard.enableRepeatEvents(false);
-	}
-
-	/**
-	 * Return to the Account Selector
-	 */
-	private void escape(){
-		mc.displayGuiScreen(new GuiAccountSelector());
-	}
-
-	/**
-	 * Add account and return to account selector
-	 */
-	private void addAccount(){
-		AltDatabase.getInstance().getAlts().add(new ExtendedAccountData(user, pass, user));
-		mc.displayGuiScreen(new GuiAccountSelector());
-	}
-
-	/**
-	 * Updates the username and password
-	 */
-	private void updateText(){
-		username.setText(user);
-		password.setText(cover);
-	}
-
-	private boolean accountNotInList(){
-		for(AccountData data : AltDatabase.getInstance().getAlts()){
-			if(EncryptionTools.decode(data.user).equals(user) && EncryptionTools.decode(data.pass).equals(pass)){
-				return false;
-			}
-		}
-		return true;
+		AltDatabase.getInstance().getAlts().add(new ExtendedAccountData(getUsername(), getPassword(), getUsername()));
 	}
 }

--- a/src/main/java/the_fireplace/ias/gui/GuiEditAccount.java
+++ b/src/main/java/the_fireplace/ias/gui/GuiEditAccount.java
@@ -20,187 +20,33 @@ import java.io.IOException;
  * The GUI where the alt is added
  * @author The_Fireplace
  */
-class GuiEditAccount extends GuiScreen {
-
-	private String user = "", pass = "", cover = "";
-	private final EnumBool premium;
-	private final int[] lastused;
-	private final int useCount;
-	private GuiTextField username;
-	private GuiTextField password;
-	private GuiButton editaccount;
+class GuiEditAccount extends AbstractAccountGui {
+	private final ExtendedAccountData data;
 	private final int selectedIndex;
 
 	public GuiEditAccount(int index){
+		super("ias.editaccount");
 		this.selectedIndex=index;
-		this.user=EncryptionTools.decode(AltDatabase.getInstance().getAlts().get(index).user);
-		this.pass=EncryptionTools.decode(AltDatabase.getInstance().getAlts().get(index).pass);
-		for(int i=0;i<pass.length();i++){
-			cover += '*';
-		}
-		if(AltDatabase.getInstance().getAlts().get(index) instanceof ExtendedAccountData){
-			lastused=((ExtendedAccountData)AltDatabase.getInstance().getAlts().get(index)).lastused;
-			useCount=((ExtendedAccountData)AltDatabase.getInstance().getAlts().get(index)).useCount;
-			premium=((ExtendedAccountData)AltDatabase.getInstance().getAlts().get(index)).premium;
+		AccountData data = AltDatabase.getInstance().getAlts().get(index);
+
+		if(data instanceof ExtendedAccountData){
+			this.data = (ExtendedAccountData) data;
 		}else{
-			lastused=JavaTools.getJavaCompat().getDate();
-			useCount=0;
-			premium=EnumBool.UNKNOWN;
+			this.data = new ExtendedAccountData(data.user, data.pass, data.user, 0, JavaTools.getJavaCompat().getDate(), EnumBool.UNKNOWN);
 		}
 	}
 
 	@Override
 	public void initGui() {
-		Keyboard.enableRepeatEvents(true);
-		this.buttonList.clear();
-		this.buttonList.add(editaccount = new GuiButton(2, this.width / 2 - 152, this.height - 28, 150, 20, I18n.format("ias.editaccount")));
-		this.buttonList.add(new GuiButton(3, this.width / 2 + 2, this.height - 28, 150, 20, I18n.format("gui.cancel")));
-		username = new GuiTextField(0, this.fontRendererObj, this.width / 2 - 100, 60, 200, 20);
-		username.setFocused(true);
-		username.setText(user);
-		password = new GuiTextField(1, this.fontRendererObj, this.width / 2 - 100, 90, 200, 20);
-		password.setText(pass);
-		editaccount.enabled = username.getText().length() > 0 && accountNotInList();
+		super.initGui();
+		setUsername(EncryptionTools.decode(data.user));
+		setPassword(EncryptionTools.decode(data.pass));
 	}
 
 	@Override
-	public void drawScreen(int par1, int par2, float par3) {
-		this.drawDefaultBackground();
-		this.drawCenteredString(fontRendererObj, I18n.format("ias.editaccount"), this.width / 2, 7, -1);
-		this.drawCenteredString(fontRendererObj, I18n.format("ias.username"), this.width / 2 - 130, 66, -1);
-		this.drawCenteredString(fontRendererObj, I18n.format("ias.password"), this.width / 2 - 130, 96, -1);
-		username.drawTextBox();
-		password.drawTextBox();
-		super.drawScreen(par1, par2, par3);
-	}
-
-	@Override
-	protected void keyTyped(char character, int keyIndex) {
-		if (keyIndex == Keyboard.KEY_ESCAPE) {
-			escape();
-		} else if (keyIndex == Keyboard.KEY_RETURN) {
-			if(username.isFocused()){
-				username.setFocused(false);
-				password.setFocused(true);
-			}else if(password.isFocused() && editaccount.enabled){
-				editAccount();
-			}
-		} else if (keyIndex == Keyboard.KEY_BACK) {
-			if (username.isFocused() && user.length() > 0) {
-				user = user.substring(0, user.length() - 1);
-			} else if (password.isFocused() && pass.length() > 0) {
-				pass = pass.substring(0, pass.length() - 1);
-				cover = cover.substring(0, cover.length() - 1);
-			}
-			updateText();
-		} else if(keyIndex == Keyboard.KEY_TAB){
-			if(username.isFocused()){
-				username.setFocused(false);
-				password.setFocused(true);
-			}else if(password.isFocused()){
-				username.setFocused(true);
-				password.setFocused(false);
-			}
-		} else if (keyIndex == Keyboard.KEY_V && (Keyboard.isKeyDown(Keyboard.KEY_LCONTROL) || Keyboard.isKeyDown(Keyboard.KEY_RCONTROL))){
-			if(username.isFocused()){
-				try {
-					user += (String)Toolkit.getDefaultToolkit().getSystemClipboard().getData(DataFlavor.stringFlavor);
-				} catch (HeadlessException e) {
-					e.printStackTrace();
-				} catch (UnsupportedFlavorException e) {
-					e.printStackTrace();
-				} catch (IOException e) {
-					e.printStackTrace();
-				}
-			}else if(password.isFocused()){
-				try {
-					pass += (String)Toolkit.getDefaultToolkit().getSystemClipboard().getData(DataFlavor.stringFlavor);
-					for(int i=0;i<((String)Toolkit.getDefaultToolkit().getSystemClipboard().getData(DataFlavor.stringFlavor)).length();i++){
-						cover += '*';
-					}
-				} catch (HeadlessException e) {
-					e.printStackTrace();
-				} catch (UnsupportedFlavorException e) {
-					e.printStackTrace();
-				} catch (IOException e) {
-					e.printStackTrace();
-				}
-			}
-		} else if (character != 0) {
-			if (username.isFocused()) {
-				user += character;
-			} else if (password.isFocused()) {
-				pass += character;
-				cover += '*';
-			}
-			updateText();
-		}
-	}
-
-	@Override
-	public void updateScreen()
+	public void complete()
 	{
-		this.username.updateCursorCounter();
-		this.password.updateCursorCounter();
-		editaccount.enabled = username.getText().length() > 0 && accountNotInList();
-		updateText();
+		AltDatabase.getInstance().getAlts().set(selectedIndex, new ExtendedAccountData(getUsername(), getPassword(), getUsername(), data.useCount, data.lastused, data.premium));
 	}
 
-	@Override
-	protected void actionPerformed(GuiButton button){
-		if (button.enabled)
-		{
-			if(button.id == 2){
-				editAccount();
-			}else if(button.id == 3){
-				escape();
-			}
-		}
-	}
-
-	@Override
-	protected void mouseClicked(int mouseX, int mouseY, int mouseButton) throws IOException
-	{
-		super.mouseClicked(mouseX, mouseY, mouseButton);
-		username.mouseClicked(mouseX, mouseY, mouseButton);
-		password.mouseClicked(mouseX, mouseY, mouseButton);
-	}
-
-	@Override
-	public void onGuiClosed()
-	{
-		Keyboard.enableRepeatEvents(false);
-	}
-
-	/**
-	 * Return to the Account Selector
-	 */
-	private void escape(){
-		mc.displayGuiScreen(new GuiAccountSelector());
-	}
-
-	/**
-	 * Add account and return to account selector
-	 */
-	private void editAccount(){
-		AltDatabase.getInstance().getAlts().set(selectedIndex, new ExtendedAccountData(user, pass, user, useCount, lastused, premium));
-		mc.displayGuiScreen(new GuiAccountSelector());
-	}
-
-	/**
-	 * Updates the username and password
-	 */
-	private void updateText(){
-		username.setText(user);
-		password.setText(cover);
-	}
-
-	private boolean accountNotInList(){
-		for(AccountData data : AltDatabase.getInstance().getAlts()){
-			if(EncryptionTools.decode(data.user).equals(user) && EncryptionTools.decode(data.pass).equals(pass)){
-				return false;
-			}
-		}
-		return true;
-	}
 }

--- a/src/main/java/the_fireplace/ias/gui/GuiPasswordField.java
+++ b/src/main/java/the_fireplace/ias/gui/GuiPasswordField.java
@@ -1,0 +1,55 @@
+package the_fireplace.ias.gui;
+
+import joptsimple.internal.Strings;
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.gui.GuiTextField;
+import org.lwjgl.input.Keyboard;
+
+public class GuiPasswordField extends GuiTextField
+{
+	public GuiPasswordField(int componentId, FontRenderer fontrendererObj, int x, int y, int par5Width, int par6Height)
+	{
+		super(componentId, fontrendererObj, x, y, par5Width, par6Height);
+	}
+
+	@Override
+	public void drawTextBox()
+	{
+		String password = getText();
+		replaceText(Strings.repeat('*', getText().length()));
+		super.drawTextBox();
+		replaceText(password);
+	}
+
+	@Override
+	public boolean textboxKeyTyped(char typedChar, int keyCode)
+	{
+		// Ignore ctrl+c and ctrl+x to prevent copying the contents of the field
+		return  !GuiScreen.isKeyComboCtrlC(keyCode) && !GuiScreen.isKeyComboCtrlX(keyCode) && super.textboxKeyTyped(typedChar, keyCode);
+	}
+
+	@Override
+	public void mouseClicked(int mouseX, int mouseY, int mouseButton)
+	{
+		// Minecraft has variable-width fonts, so replace the text with asterisks so that the correct cursor position is calculated
+		String password = getText();
+		replaceText(Strings.repeat('*', getText().length()));
+		super.mouseClicked(mouseX, mouseY, mouseButton);
+		replaceText(password);
+
+	}
+
+	/**
+	 * Sets the text of the field while maintaining the cursor positions
+	 * @param newText
+	 */
+	private void replaceText(String newText)
+	{
+		int cursorPosition = getCursorPosition();
+		int selectionEnd = getSelectionEnd();
+		setText(newText);
+		setCursorPosition(cursorPosition);
+		setSelectionPos(selectionEnd);
+	}
+}


### PR DESCRIPTION
I tried this mod out earlier today and discovered that email accounts that I'm using are longer than 32 characters and don't work within the UI, which followed the default of 32 characters max.  Since I was already editing the project, I made a few other enhancements.  I've of course tested all of these, but I encourage you to test them yourself as well.

Changes:
- All text field operations now work on the username and password fields, with the exception of copying from the password field.  This means you can now copy+paste, move the cursor with the arrow keys, select multiple characters with shift, and more.
- The character limit on usernames and passwords was increased from 32 to 64.
- You can now switch to online from offline mode without having to switch accounts.
- The account currently in use now appears green on the account selection screen.

I've compiled and am using this locally, so if you don't want to merge this PR I don't really care.  I made these changes already so I figured I'd notify you in case you want to include them in the mod.